### PR TITLE
Activate indentation check

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -31,6 +31,7 @@
     <rule ref="Generic.Functions.CallTimePassByReference"/>
     <rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
     <rule ref="Generic.PHP.LowerCaseConstant"/>
+    <rule ref="Generic.WhiteSpace.ScopeIndent"/>
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
     <rule ref="Squiz.ControlStructures.ControlSignature"/>
     <rule ref="Squiz.ControlStructures.ForEachLoopDeclaration"/>


### PR DESCRIPTION
This PR activate indentation checks on PHP files (4 spaces) :

``` php
// Valid
class MyClass
{
    public function myFunction()
    {
        echo 'foo';
    }
}

// Invalid
class MyClass
{
  public function myFunction()
  {
      echo 'foo';
  }
}
```
