### PR TITLE
Add sniffs for a single space before comment first word and for the firs...

### DIFF
--- a/Sniffs/Formatting/CapitalizeFirstCommentWordSniff.php
+++ b/Sniffs/Formatting/CapitalizeFirstCommentWordSniff.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Symfony2_Sniffs_Formatting_CapitalizeFirstCommentWordSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Symfony2_Sniffs_Formatting_CapitalizeFirstCommentWordSniff.
+ *
+ * Ensures the first letter of the word of a comment is uppercase
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Symfony2_Sniffs_Formatting_CapitalizeFirstCommentWordSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_COMMENT);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr)]['code'] == T_COMMENT) {
+            if (preg_match('#(//\s?[a-z])#', $tokens[($stackPtr)]['content'])) {
+                $phpcsFile->addError('An inline comment must be capitalized', $stackPtr, 'NoCapitalize');
+            }
+        }
+    }
+}
+
+?>

--- a/Sniffs/Formatting/SpaceAfterCommentTagSniff.php
+++ b/Sniffs/Formatting/SpaceAfterCommentTagSniff.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Symfony2_Sniffs_Formatting_SpaceAfterCommentTagSniff.
+ *
+ * PHP version 5
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+
+/**
+ * Symfony2_Sniffs_Formatting_SpaceAfterCommentTagSniff.
+ *
+ * Ensures there is a single space at the beginning of inline comments.
+ *
+ * @category  PHP
+ * @package   PHP_CodeSniffer
+ * @author    Greg Sherwood <gsherwood@squiz.net>
+ * @author    Marc McIntyre <mmcintyre@squiz.net>
+ * @copyright 2006-2012 Squiz Pty Ltd (ABN 77 084 670 600)
+ * @license   https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt BSD Licence
+ * @version   Release: @package_version@
+ * @link      http://pear.php.net/package/PHP_CodeSniffer
+ */
+class Symfony2_Sniffs_Formatting_SpaceAfterCommentTagSniff implements PHP_CodeSniffer_Sniff
+{
+
+    /**
+     * Returns an array of tokens this test wants to listen for.
+     *
+     * @return array
+     */
+    public function register()
+    {
+        return array(T_COMMENT);
+    }
+
+    /**
+     * Processes this test, when one of its tokens is encountered.
+     *
+     * @param PHP_CodeSniffer_File $phpcsFile The file being scanned.
+     * @param int                  $stackPtr  The position of the current token in
+     *                                        the stack passed in $tokens.
+     *
+     * @return void
+     */
+    public function process(PHP_CodeSniffer_File $phpcsFile, $stackPtr)
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if ($tokens[($stackPtr)]['code'] == T_COMMENT) {
+            if (!preg_match('#(//\s[^\s.]|/\*|\s\*(\s|/))(.*)#', $tokens[($stackPtr)]['content'])) {
+                $phpcsFile->addError('An inline comment must begin with a single space', $stackPtr, 'Space');
+            }
+        }
+    }
+}
+
+?>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -85,4 +85,12 @@
     <rule ref="Symfony2.Commenting.ClassComment.SpacingBeforeTags">
         <message>There should always be a description, followed by a blank line, before the tags of a class comment.</message>
     </rule>
+
+    <rule ref="Symfony2.Formatting.SpaceAfterCommentTag">
+        <severity>0</severity>
+    </rule>
+
+    <rule ref="Symfony2.Formatting.CapitalizeFirstCommentWord">
+        <severity>0</severity>
+    </rule>
 </ruleset>


### PR DESCRIPTION
...t word capitalization

Capitalization:

``` php
//Valid
// Valid

// invalid
//invalid
```

Space:

``` php
// Valid
// valid

//invalid
//Invalid

/*
 * Valid
 */

/*
 *invalid
 */
```
